### PR TITLE
monitoring processes (and stopping expired processes)

### DIFF
--- a/dotnet_channels_process/cmd/main.go
+++ b/dotnet_channels_process/cmd/main.go
@@ -21,8 +21,8 @@ func pumpData(ctx context.Context, dataProcessor *data.BackgroundDataProcessor) 
 	// push data immediately
 	// because Push will block till its read
 	// You need to go this, else Execute wont be called
-	go dataProcessor.Push(data.DataWithKey{})
-	go dataProcessor.Push(data.DataWithKey{})
+	go dataProcessor.Push(data.DataWithKey{Key: "base"})
+	go dataProcessor.Push(data.DataWithKey{Key: "___"})
 
 	go func() {
 		// push data after 400 millisecond sor abort if cancelled before that
@@ -50,6 +50,12 @@ func pumpData(ctx context.Context, dataProcessor *data.BackgroundDataProcessor) 
 			go dataProcessor.Push(data.DataWithKey{})
 			fmt.Println("After pushing")
 		}
+	}()
+
+	go func() {
+		defer threeSecondsInterval.Stop()
+		defer twoSecondsInterval.Stop()
+		<-ctx.Done()
 	}()
 
 	func() {

--- a/dotnet_channels_process/pkg/data/processormonitor.go
+++ b/dotnet_channels_process/pkg/data/processormonitor.go
@@ -1,0 +1,90 @@
+package data
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+type BackgroundDataProcessorMonitor struct {
+	mu                            sync.Mutex
+	log                           *log.Logger
+	processors                    TProcess
+	processorExpiryScanningPeriod time.Duration
+	processorExpiryThreshold      time.Duration
+	abortTaskC                    context.CancelFunc
+}
+
+type TProcess = map[string]*KeySpecificDataProcessor
+
+func newDataProcessorMonitor(dataProcessors TProcess, l *log.Logger) *BackgroundDataProcessorMonitor {
+	return &BackgroundDataProcessorMonitor{
+		log:                           l,
+		processors:                    dataProcessors,
+		processorExpiryScanningPeriod: time.Duration(500 * time.Millisecond),
+		processorExpiryThreshold:      time.Duration(1 * time.Second),
+	}
+}
+
+func (m *BackgroundDataProcessorMonitor) StartMonitoring(ctx context.Context) {
+	newCtx, newCtxCancelFn := context.WithCancel(ctx)
+	m.abortTaskC = newCtxCancelFn
+	ticker := time.NewTicker(m.processorExpiryScanningPeriod)
+	go func() {
+		for {
+			select {
+			case <-newCtx.Done():
+				// cancellation from context
+				fmt.Println("monitoring stopped")
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				// our processor expiry scanner has ticked
+				func() {
+					m.log.Println("expiry period reached")
+					m.mu.Lock()
+					defer m.mu.Unlock()
+
+					m.log.Printf("checking %d processors for work expiry\n", len(m.processors))
+
+					for index, p := range m.processors {
+						if m.isExpired(p) {
+							// block till we stop processing
+							m.log.Printf("processor (%s) is expired, stopping...\n", p.GetProcessorKey())
+							p.StopProcessing()
+
+							delete(m.processors, index)
+
+							m.log.Printf("Removed data processor for data key %s\n", p.GetProcessorKey())
+						}
+					}
+
+				}()
+			}
+
+		}
+	}()
+
+}
+
+func (m *BackgroundDataProcessorMonitor) StopMonitoring() {
+	// trigger the cancelFn of
+	if m.abortTaskC != nil {
+		m.abortTaskC()
+	}
+
+	m.abortTaskC = nil
+}
+
+func (m *BackgroundDataProcessorMonitor) isExpired(p *KeySpecificDataProcessor) bool {
+	return time.Now().UTC().Sub(p.LastProcessingTimestamp()) > m.processorExpiryThreshold
+}
+
+func CreateAndStartMonitor(ctx context.Context, dataProcessors TProcess, l *log.Logger) *BackgroundDataProcessorMonitor {
+	m := newDataProcessorMonitor(dataProcessors, l)
+
+	m.StartMonitoring(ctx)
+	return m
+}


### PR DESCRIPTION
stop tickers, else they'll keep ticking.
or just break out of the loop on the ctx.Done().